### PR TITLE
Pull up custom attributes, name and declaring type into interfaces

### DIFF
--- a/MiddleweightReflection/IMrHasCustomAttributes.cs
+++ b/MiddleweightReflection/IMrHasCustomAttributes.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Immutable;
+
+namespace MiddleweightReflection
+{
+    public interface IMrHasCustomAttributes : IMrNamedElement
+    {
+        ImmutableArray<MrCustomAttribute> GetCustomAttributes();
+    }
+}

--- a/MiddleweightReflection/IMrNamedElement.cs
+++ b/MiddleweightReflection/IMrNamedElement.cs
@@ -1,0 +1,7 @@
+﻿namespace MiddleweightReflection
+{
+    public interface IMrNamedElement
+    {
+        string GetName();
+    }
+}

--- a/MiddleweightReflection/IMrTypeMember.cs
+++ b/MiddleweightReflection/IMrTypeMember.cs
@@ -1,0 +1,7 @@
+﻿namespace MiddleweightReflection
+{
+    public interface IMrTypeMember : IMrNamedElement
+    {
+        MrType DeclaringType { get; }
+    }
+}

--- a/MiddleweightReflection/MrEvent.cs
+++ b/MiddleweightReflection/MrEvent.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace MiddleweightReflection
 {
-    public class MrEvent
+    public class MrEvent : IMrHasCustomAttributes, IMrTypeMember
     {
         public EventDefinitionHandle DefinitionHandle { get; }
         public MrType DeclaringType { get; }

--- a/MiddleweightReflection/MrField.cs
+++ b/MiddleweightReflection/MrField.cs
@@ -6,7 +6,7 @@ using System.Reflection.Metadata;
 
 namespace MiddleweightReflection
 {
-    public class MrField
+    public class MrField : IMrHasCustomAttributes, IMrTypeMember
     {
         public MrType DeclaringType { get; }
         public FieldDefinitionHandle DefinitionHandle { get; }

--- a/MiddleweightReflection/MrMethod.cs
+++ b/MiddleweightReflection/MrMethod.cs
@@ -12,7 +12,7 @@ namespace MiddleweightReflection
     /// <summary>
     /// Represents a method on the DeclaringType
     /// </summary>
-    public class MrMethod
+    public class MrMethod : IMrHasCustomAttributes, IMrTypeMember
     {
         public MrType DeclaringType { get; private set; }
         public MethodDefinitionHandle MethodDefinitionHandle { get; private set; }

--- a/MiddleweightReflection/MrProperty.cs
+++ b/MiddleweightReflection/MrProperty.cs
@@ -12,7 +12,7 @@ namespace MiddleweightReflection
     /// <summary>
     /// A property of an MRType
     /// </summary>
-    public class MrProperty
+    public class MrProperty : IMrHasCustomAttributes, IMrTypeMember
     {
         public MrType DeclaringType { get; }
         public PropertyDefinitionHandle DefinitionHandle { get; }

--- a/MiddleweightReflection/MrType.cs
+++ b/MiddleweightReflection/MrType.cs
@@ -16,7 +16,7 @@ namespace MiddleweightReflection
     /// <summary>
     /// Represents a type from an assembly (get this from an MRAssembly class)
     /// </summary>
-    public class MrType
+    public class MrType : IMrHasCustomAttributes
     {
         internal TypeDefinitionHandle TypeDefinitionHandle { get; }
         internal TypeDefinition TypeDefinition { get; }


### PR DESCRIPTION
This allows e.g. reasoning over custom attributes regardless of whether something is a property, field, method, etc.