### PR TITLE
Resolve fake types in GetBaseType

### DIFF
--- a/MiddleweightReflection/MrLoadContext.cs
+++ b/MiddleweightReflection/MrLoadContext.cs
@@ -432,7 +432,7 @@ namespace MiddleweightReflection
             public MrType ReplacementType { get; set; }
         }
 
-        private void RaiseFakeTypeRequired(string fullTypeName, string assemblyName, out MrType type)
+        internal void RaiseFakeTypeRequired(string fullTypeName, string assemblyName, out MrType type)
         {
             type = null;
             if (FakeTypeRequired != null)

--- a/MiddleweightReflection/MrType.cs
+++ b/MiddleweightReflection/MrType.cs
@@ -360,7 +360,12 @@ namespace MiddleweightReflection
         /// <returns></returns>
         public MrType GetBaseType()
         {
-            if (IsTypeCode || IsFakeType || IsGenericParameter)
+            if (IsFakeType)
+            {
+                Assembly.LoadContext.RaiseFakeTypeRequired(GetFullName(), Assembly.FullName, out MrType subst);
+                return subst.GetBaseType();
+            }
+            if (IsTypeCode || IsGenericParameter)
             {
                 return null;
             }

--- a/MiddleweightReflection/MrType.cs
+++ b/MiddleweightReflection/MrType.cs
@@ -363,9 +363,12 @@ namespace MiddleweightReflection
             if (IsFakeType)
             {
                 Assembly.LoadContext.RaiseFakeTypeRequired(GetFullName(), Assembly.FullName, out MrType subst);
-                return subst.GetBaseType();
+                if (subst != null)
+                {
+                    return subst.GetBaseType();
+                }
             }
-            if (IsTypeCode || IsGenericParameter)
+            if (IsTypeCode || IsFakeType || IsGenericParameter)
             {
                 return null;
             }


### PR DESCRIPTION
Fixes #6 
GetBaseType would just bail when a type in assembly A inherits from a type in assembly B. Use the load context to resolve types.