### PR TITLE
Don't guess at .Net assembly locations

### DIFF
--- a/MiddleweightReflection/MiddleweightReflection.csproj
+++ b/MiddleweightReflection/MiddleweightReflection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Deterministic>false</Deterministic>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <Description>.Net library to read .Net Assembly and Windows WinMD metadata files, based on System.Reflection.Metadata</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>

--- a/MiddleweightReflection/MiddleweightReflection.csproj
+++ b/MiddleweightReflection/MiddleweightReflection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Deterministic>false</Deterministic>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <Description>.Net library to read .Net Assembly and Windows WinMD metadata files, based on System.Reflection.Metadata</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>

--- a/MiddleweightReflection/MrAssembly.cs
+++ b/MiddleweightReflection/MrAssembly.cs
@@ -75,36 +75,6 @@ namespace MiddleweightReflection
         public string Location { get; private set; }
         public string FullName => Name;
 
-        void CreateReaderFromAssemblyName(string requestedName)
-        {
-            if (requestedName.ToLower() == "mscorlib")
-            {
-                Location = (typeof(string).Assembly).Location;
-            }
-            else if (requestedName == "System")
-            {
-                Location = typeof(NetTcpStyleUriParser).Assembly.Location;
-            }
-            else
-            {
-                Location = _loadContext.AssemblyPathFromName(requestedName);
-            }
-
-            if (Location == null)
-            {
-                IsFakeAssembly = true;
-                return;
-            }
-
-            CreateReaderFromPath(Location);
-
-            Name = this.Reader.GetAssemblyDefinition().Name.AsString(this);
-            if (Name != Name)
-            {
-                throw new Exception($"Expected assembly name '{requestedName}', actual is '{Name}'");
-            }
-
-        }
 
         public MetadataReader Reader;
         unsafe void CreateReaderFromPath(string path)

--- a/MiddleweightReflection/MrLoadContext.cs
+++ b/MiddleweightReflection/MrLoadContext.cs
@@ -212,8 +212,6 @@ namespace MiddleweightReflection
         {
             return LoadAssemblyFromBytes(buffer, null);
         }
-        
-
 
         /// <summary>
         /// Load given the assembly name. If already loaded, return that.
@@ -250,8 +248,6 @@ namespace MiddleweightReflection
                 }
                 return assembly;
             }
-
-
 
             CreateReaderFromAssemblyName(requestedName, out var reader, out var path);
             return LoadFromReader(reader, requestedName, path, implicitLoad);

--- a/MiddleweightReflection/MrLoadContext.cs
+++ b/MiddleweightReflection/MrLoadContext.cs
@@ -194,9 +194,9 @@ namespace MiddleweightReflection
         /// <summary>
         /// Load an assembly from memory. If already loaded, return that.
         /// </summary>
-        /// <param name="path"></param>
-        /// <returns></returns>
-        public MrAssembly LoadAssemblyFromBytes(byte[] buffer)
+        /// <param name="buffer">Assembly contents</param>
+        /// <param name="path">Location of the assembly (optional and not used, just used to return from the Location property</param>
+        public MrAssembly LoadAssemblyFromBytes(byte[] buffer, string path)
         {
             var reader = CreateReaderFromBytes(buffer);
             var name = reader.GetString(reader.GetAssemblyDefinition().Name);
@@ -206,8 +206,18 @@ namespace MiddleweightReflection
                 return assembly;
             }
 
-            return LoadFromReader(reader, name, null, implicitLoad: false);
+            return LoadFromReader(reader, name, path, implicitLoad: false);
         }
+
+        /// <summary>
+        /// Load an assembly from memory. If already loaded, return that.
+        /// </summary>
+        public MrAssembly LoadAssemblyFromBytes(byte[] buffer)
+        {
+            return LoadAssemblyFromBytes(buffer, null);
+        }
+        
+
 
         /// <summary>
         /// Load given the assembly name. If already loaded, return that.

--- a/MiddleweightReflection/MrLoadContext.cs
+++ b/MiddleweightReflection/MrLoadContext.cs
@@ -39,7 +39,7 @@ namespace MiddleweightReflection
                 MetadataReaderOptions = MetadataReaderOptions.ApplyWindowsRuntimeProjections;
             }
 
-            LoadFromAssemblyName("mscorlib", implicitLoad: true);
+            //LoadFromAssemblyName("mscorlib", implicitLoad: true);
         }
 
         /// <summary>

--- a/Test/Resources/ExpectedOutput.txt
+++ b/Test/Resources/ExpectedOutput.txt
@@ -77,7 +77,7 @@ public enum UnitTestSampleAssembly.FlagsEnum : System.Enum
 
 public class UnitTestSampleAssembly.TestAttribute : System.Attribute
     AutoLayout, AnsiClass, Class, Public, BeforeFieldInit
-    [AttributeUsageAttribute(32767)]
+    [AttributeUsageAttribute]
     public TestAttribute()
 
 public class Class3+NestedInClass3 : System.Object (nested)

--- a/Test/Resources/ExpectedOutput.txt
+++ b/Test/Resources/ExpectedOutput.txt
@@ -10,6 +10,7 @@ public class UnitTestSampleAssembly.Class1<T1,T2,T3> : System.Object
     public System.Int32 this.[System.Int32]
     UnitTestSampleAssembly.Class1<T1,T2,T3> Self { public get; }
     UnitTestSampleAssembly.Class1<System.IO.Stream,System.Int32,System.Object> ClosedSelf { public get; }
+    System.Object ObjectProperty { public get; }
     public System.EventHandler<System.EventArgs> PublicEvent { add; remove; }
     public static System.String StaticPublicStringMethod2(System.String arg1, System.Int32 arg2)
     protected System.Void ProtectedVirtualVoidMethod0()

--- a/Test/UnitTestSampleAssembly/Class1.cs
+++ b/Test/UnitTestSampleAssembly/Class1.cs
@@ -43,6 +43,8 @@ namespace UnitTestSampleAssembly
         static int PrivateStaticIntField = 1;
         const int PrivateConstIntField = 2;
         public int PublicIntField;
+
+        public object ObjectProperty { get; }
     }
 
     public class Class2<T1>


### PR DESCRIPTION
* Add an optional path parameter to LoadAssemblyFromBytes (not used but returned from the Location property)
* Don't try to auto-load mscorlib etc, instead let them be faked, or let the caller provide them
